### PR TITLE
Align admin schedule modal styles with public calendar

### DIFF
--- a/admin/calendars.php
+++ b/admin/calendars.php
@@ -1186,15 +1186,15 @@ include __DIR__.'/header.php';
         <div class="modal-dialog modal-lg modal-dialog-centered">
             <div class="modal-content">
                 <form id="scheduleForm" enctype="multipart/form-data">
-                    <div class="modal-header modal-header-gradient">
-                        <div class="modal-header-content w-100">
+                    <div class="modal-header">
+                        <div class="modal-header-content">
                             <h5 class="modal-title">
                                 <i class="bi bi-calendar-plus"></i>
                                 Schedule Post for <?php echo htmlspecialchars($current_store['name']); ?>
                             </h5>
                             <p class="modal-subtitle">Posting as Administrator</p>
                         </div>
-                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
                         <div class="schedule-form-grid">
@@ -1204,23 +1204,36 @@ include __DIR__.'/header.php';
                                     <i class="bi bi-pencil-square"></i>
                                     <span>Post Content</span>
                                 </div>
-                                <div class="form-group mb-3">
+                                <div class="form-group">
                                     <label for="postText" class="form-label">
-                                        Message <span class="text-danger">*</span>
+                                        What would you like to share?
+                                        <span class="required">*</span>
                                     </label>
-                                    <textarea class="form-control" id="postText" name="text" rows="5" required maxlength="500"></textarea>
-                                    <div class="char-counter text-end mt-1">
-                                        <span id="charCount">0</span> / 500
+                                    <textarea
+                                            class="form-control form-control-modern"
+                                            id="postText"
+                                            name="text"
+                                            rows="5"
+                                            placeholder="Write your post here..."
+                                            required
+                                            maxlength="500"></textarea>
+                                    <div class="char-counter">
+                                        <span id="charCount">0</span> / 500 characters
                                     </div>
                                 </div>
 
                                 <div class="form-group">
                                     <label for="postHashtags" class="form-label">
-                                        <i class="bi bi-hash"></i> Hashtags
+                                        <i class="bi bi-hash"></i>
+                                        Hashtags
                                     </label>
-                                    <input type="text" class="form-control" id="postHashtags" name="hashtags"
-                                           placeholder="Enter hashtags separated by commas">
-                                    <small class="form-text text-muted">Don't include the # symbol</small>
+                                    <input
+                                            type="text"
+                                            class="form-control form-control-modern"
+                                            id="postHashtags"
+                                            name="hashtags"
+                                            placeholder="Enter hashtags separated by commas (e.g., marketing, social, business)">
+                                    <small class="form-text">Tip: Don't include the # symbol, we'll add it for you</small>
                                 </div>
                             </div>
 
@@ -1231,27 +1244,48 @@ include __DIR__.'/header.php';
                                     <span>Schedule Settings</span>
                                 </div>
 
-                                <div class="form-group mb-3">
+                                <div class="form-group">
                                     <label for="postDate" class="form-label">
-                                        Date <span class="text-danger">*</span>
+                                        Date
+                                        <span class="required">*</span>
                                     </label>
-                                    <input type="text" class="form-control" id="postDate" required>
+                                    <div class="date-time-wrapper">
+                                        <input
+                                                type="text"
+                                                class="form-control form-control-modern"
+                                                id="postDate"
+                                                placeholder="Select date"
+                                                required>
+                                        <i class="bi bi-calendar-event input-icon"></i>
+                                    </div>
                                 </div>
 
-                                <div class="form-group mb-3">
+                                <div class="form-group">
                                     <label for="postTime" class="form-label">
-                                        Time <span class="text-danger">*</span>
+                                        Time
+                                        <span class="required">*</span>
                                     </label>
-                                    <input type="text" class="form-control" id="postTime" required>
+                                    <div class="date-time-wrapper">
+                                        <input
+                                                type="text"
+                                                class="form-control form-control-modern"
+                                                id="postTime"
+                                                placeholder="Select time"
+                                                required>
+                                        <i class="bi bi-clock input-icon"></i>
+                                    </div>
                                 </div>
 
+                                <!-- Hidden combined field for backend -->
                                 <input type="hidden" id="postSchedule" name="scheduled_time">
                                 <input type="hidden" name="store_id" value="<?php echo $selected_store_id; ?>">
                                 <input type="hidden" name="admin_post" value="1">
 
                                 <div class="form-group">
-                                    <label class="form-label">
-                                        <i class="bi bi-share"></i> Social Profiles <span class="text-danger">*</span>
+                                    <label for="postProfiles" class="form-label">
+                                        <i class="bi bi-share"></i>
+                                        Social Profiles
+                                        <span class="required">*</span>
                                     </label>
                                     <div class="profiles-selector">
                                         <?php foreach ($profiles as $prof):
@@ -1261,10 +1295,12 @@ include __DIR__.'/header.php';
                                             $color = $networkInfo['color'] ?? '#6c757d';
                                             ?>
                                             <label class="profile-checkbox">
-                                                <input type="checkbox" name="profile_ids[]"
-                                                       value="<?php echo htmlspecialchars($prof['id']); ?>"
-                                                       class="profile-checkbox-input">
-                                                <div class="profile-checkbox-label" data-profile-color="<?php echo $color; ?>">
+                                                <input
+                                                        type="checkbox"
+                                                        name="profile_ids[]"
+                                                        value="<?php echo htmlspecialchars($prof['id']); ?>"
+                                                        class="profile-checkbox-input">
+                                                <div class="profile-checkbox-label" style="--profile-color: <?php echo $color; ?>;">
                                                     <i class="bi <?php echo $icon; ?>"></i>
                                                     <div class="profile-info">
                                                         <span class="profile-network"><?php echo htmlspecialchars($prof['network'] ?? ''); ?></span>
@@ -1275,7 +1311,7 @@ include __DIR__.'/header.php';
                                             </label>
                                         <?php endforeach; ?>
                                     </div>
-                                    <div class="profiles-error text-danger d-none">
+                                    <div class="profiles-error" style="display: none;">
                                         Please select at least one social profile
                                     </div>
                                 </div>
@@ -1289,14 +1325,13 @@ include __DIR__.'/header.php';
                                 </div>
                                 <div class="form-group">
                                     <div class="media-upload-area">
-                                        <input type="file" class="form-control d-none" id="postMedia" name="media[]"
-                                               accept="image/*,video/*" multiple>
-                                        <div class="media-upload-content text-center py-5" id="mediaUploadContent">
-                                            <i class="bi bi-cloud-arrow-up upload-icon"></i>
-                                            <p class="mt-2">Click to upload or drag and drop</p>
-                                            <p class="text-muted small">PNG, JPG, GIF or MP4 (max. 10MB each)</p>
+                                        <input type="file" class="form-control" id="postMedia" name="media[]" accept="image/*,video/*" multiple style="display: none;">
+                                        <div class="media-upload-content" id="mediaUploadContent">
+                                            <i class="bi bi-cloud-arrow-up"></i>
+                                            <p class="upload-text">Click to upload or drag and drop</p>
+                                            <p class="upload-subtext">PNG, JPG, GIF or MP4 (max. 10MB each, up to 4 files)</p>
                                         </div>
-                                        <div class="media-preview-grid d-none" id="mediaPreviewGrid"></div>
+                                        <div class="media-preview-grid" id="mediaPreviewGrid" style="display: none;"></div>
                                     </div>
                                 </div>
                             </div>
@@ -1349,10 +1384,6 @@ include __DIR__.'/header.php';
 
             document.querySelectorAll('.network-stat[data-network-color]').forEach(function(el) {
                 el.style.setProperty('--network-color', el.dataset.networkColor);
-            });
-
-            document.querySelectorAll('.profile-checkbox-label[data-profile-color]').forEach(function(el) {
-                el.style.setProperty('--profile-color', el.dataset.profileColor);
             });
 
             // Store events and configurations

--- a/admin/inc/css/style.css
+++ b/admin/inc/css/style.css
@@ -5417,3 +5417,411 @@ table th, table td {
     padding: 0.6rem 0.75rem;
     line-height: 1.4;
 }
+
+/* ===== SCHEDULE POST MODAL UNIQUE STYLES ===== */
+
+/* Modal Header Content */
+#scheduleModal .modal-header-content h5 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+#scheduleModal .modal-header-content h5 i {
+    font-size: 1.75rem;
+}
+
+#scheduleModal .modal-subtitle {
+    margin: 0.5rem 0 0 0;
+    font-size: 0.95rem;
+    opacity: 0.9;
+}
+
+/* Schedule Form Grid */
+.schedule-form-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+}
+
+.form-section {
+    background: white;
+    border-radius: 16px;
+    padding: 1.5rem;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+}
+
+.form-section.full-width {
+    grid-column: 1 / -1;
+}
+
+.section-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+    color: #2c3e50;
+    margin-bottom: 1.5rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 2px solid #e9ecef;
+}
+
+.section-header i {
+    color: #667eea;
+    font-size: 1.25rem;
+}
+
+/* Form Elements */
+.form-label .required {
+    color: #dc3545;
+    margin-left: 0.25rem;
+}
+
+.form-control-modern {
+    width: 100%;
+    padding: 0.875rem 1rem;
+    border: 2px solid #e0e0e0;
+    border-radius: 12px;
+    font-size: 0.95rem;
+    transition: all 0.3s ease;
+    background: white;
+}
+
+.form-control-modern:focus {
+    outline: none;
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+}
+
+textarea.form-control-modern {
+    resize: vertical;
+    min-height: 120px;
+    font-family: inherit;
+    line-height: 1.5;
+}
+
+.form-text {
+    display: block;
+    margin-top: 0.5rem;
+    font-size: 0.875rem;
+    color: #6c757d;
+}
+
+/* Date Time Wrapper */
+.date-time-wrapper {
+    position: relative;
+}
+
+.date-time-wrapper .input-icon {
+    position: absolute;
+    right: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #6c757d;
+    pointer-events: none;
+}
+
+.date-time-wrapper input {
+    padding-right: 3rem;
+}
+
+/* Profile Selector Checkboxes */
+.profiles-selector {
+    display: grid;
+    gap: 0.75rem;
+    max-height: 250px;
+    overflow-y: auto;
+    padding: 0.5rem;
+    background: #f8f9fa;
+    border-radius: 12px;
+}
+
+.profile-checkbox {
+    display: block;
+    cursor: pointer;
+}
+
+.profile-checkbox-input {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.profile-checkbox-label {
+    display: flex;
+    align-items: center;
+    padding: 1rem;
+    background: white;
+    border: 2px solid #e0e0e0;
+    border-radius: 12px;
+    transition: all 0.3s ease;
+    position: relative;
+}
+
+.profile-checkbox-label:hover {
+    border-color: var(--profile-color);
+    transform: translateX(5px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.profile-checkbox-input:checked + .profile-checkbox-label {
+    background: linear-gradient(135deg,
+    color-mix(in srgb, var(--profile-color) 10%, white),
+    color-mix(in srgb, var(--profile-color) 5%, white));
+    border-color: var(--profile-color);
+}
+
+.profile-checkbox-label i:first-child {
+    font-size: 1.5rem;
+    color: var(--profile-color);
+    margin-right: 1rem;
+}
+
+.profile-info {
+    flex: 1;
+}
+
+.profile-network {
+    display: block;
+    font-weight: 600;
+    color: #2c3e50;
+    font-size: 0.95rem;
+}
+
+.profile-username {
+    display: block;
+    color: #6c757d;
+    font-size: 0.875rem;
+    margin-top: 0.25rem;
+}
+
+.check-icon {
+    color: var(--profile-color);
+    font-size: 1.25rem;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.profile-checkbox-input:checked + .profile-checkbox-label .check-icon {
+    opacity: 1;
+}
+
+.profiles-error {
+    color: #dc3545;
+    font-size: 0.875rem;
+    margin-top: 0.5rem;
+}
+
+/* Media Upload */
+.media-upload-area {
+    position: relative;
+    border: 3px dashed #e0e0e0;
+    border-radius: 16px;
+    overflow: hidden;
+    transition: all 0.3s ease;
+    min-height: 200px;
+}
+
+.media-upload-area:hover {
+    border-color: #667eea;
+    background: #f5f7ff;
+}
+
+.media-upload-area.dragging {
+    border-color: #667eea;
+    background: #f5f7ff;
+    transform: scale(1.02);
+}
+
+.media-upload-content {
+    padding: 3rem;
+    text-align: center;
+    cursor: pointer;
+}
+
+.media-upload-content i {
+    font-size: 3rem;
+    color: #667eea;
+    margin-bottom: 1rem;
+    display: block;
+}
+
+.media-preview {
+    position: relative;
+    padding: 1rem;
+}
+
+.media-preview img,
+.media-preview video {
+    max-width: 100%;
+    max-height: 300px;
+    border-radius: 12px;
+    display: block;
+    margin: 0 auto;
+}
+
+.remove-media {
+    position: absolute;
+    top: 1.5rem;
+    right: 1.5rem;
+    background: white;
+    border: none;
+    border-radius: 50%;
+    width: 2.5rem;
+    height: 2.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    transition: all 0.3s ease;
+}
+
+.remove-media:hover {
+    transform: scale(1.1);
+    background: #dc3545;
+    color: white;
+}
+
+.remove-media i {
+    font-size: 1.25rem;
+}
+
+/* Media Upload Info Alert */
+.media-upload-info {
+    margin-bottom: 1rem;
+}
+
+.media-upload-info .alert {
+    border-radius: 12px;
+    border: none;
+    background: linear-gradient(135deg, #e3f2fd 0%, #bbdefb 100%);
+    color: #0d47a1;
+}
+
+.media-upload-info .alert ul {
+    margin-bottom: 0;
+    padding-left: 1.5rem;
+}
+
+.media-upload-info .alert li {
+    margin-bottom: 0.25rem;
+    font-size: 0.875rem;
+}
+
+/* Media Preview Grid */
+.media-preview-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: 1rem;
+    padding: 1rem;
+    background: #f8f9fa;
+    border-radius: 12px;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.media-preview-item {
+    position: relative;
+    background: white;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.media-preview-image,
+.media-preview-video {
+    width: 100%;
+    height: 120px;
+    object-fit: cover;
+    display: block;
+}
+
+.remove-media-item {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    background: white;
+    border: none;
+    border-radius: 50%;
+    width: 1.75rem;
+    height: 1.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+    transition: all 0.3s ease;
+    z-index: 10;
+}
+
+.remove-media-item:hover {
+    background: #dc3545;
+    color: white;
+    transform: scale(1.1);
+}
+
+.remove-media-item i {
+    font-size: 1rem;
+}
+
+.media-filename {
+    padding: 0.5rem;
+    font-size: 0.75rem;
+    color: #6c757d;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    background: white;
+    border-top: 1px solid #e9ecef;
+}
+
+/* Larger time picker controls */
+.flatpickr-time .numInputWrapper {
+    width: 70px;
+    height: 45px;
+}
+
+.flatpickr-time .numInputWrapper input {
+    font-size: 1.25rem;
+}
+
+.flatpickr-time .flatpickr-am-pm {
+    height: 45px;
+    font-size: 1.25rem;
+}
+
+.flatpickr-time .numInputWrapper span.arrowUp,
+.flatpickr-time .numInputWrapper span.arrowDown {
+    height: 45px;
+}
+
+/* Alert Info Style in Modal */
+#scheduleModal .alert-info {
+    background: linear-gradient(135deg, #e3f2fd 0%, #bbdefb 100%);
+    border: none;
+    color: #0d47a1;
+}
+
+#scheduleModal .alert-info strong {
+    color: #01579b;
+}
+
+/* Responsive for Schedule Modal */
+@media (max-width: 768px) {
+    .schedule-form-grid {
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+    }
+
+    .profiles-selector {
+        max-height: 200px;
+    }
+
+    .media-upload-content {
+        padding: 2rem 1rem;
+    }
+}


### PR DESCRIPTION
## Summary
- Mirror the schedule post modal in `admin/calendars.php` to match the public calendar version, using modern form controls and profile selector styles.
- Add comprehensive schedule modal CSS to `admin/inc/css/style.css` for consistent styling across the admin interface.

## Testing
- `php -l admin/calendars.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6896560ffd2c83268cd27dd54485474b