### PR TITLE
Add Reports dropdown and move settings icon to admin toolbar

### DIFF
--- a/admin/calendars.php
+++ b/admin/calendars.php
@@ -1022,10 +1022,6 @@ include __DIR__.'/header.php';
                     </button>
                 <?php endif; ?>
 
-                <a href="/admin/schedule-reports.php" class="btn btn-outline-primary" target="_blank">
-                    <i class="fa fa-chart-line"></i> Social Health Report
-                </a>
-
                 <button onclick="refreshCalendar()" class="btn btn-outline-primary">
                     <i class="bi bi-arrow-clockwise"></i> Refresh
                 </button>

--- a/admin/header.php
+++ b/admin/header.php
@@ -93,10 +93,15 @@ $version = trim(file_get_contents(__DIR__.'/../VERSION'));
                 <i class="bi bi-people"></i>
                 <span>Users</span>
             </a>
-            <a class="nav-link<?php if($active==='settings') echo ' active'; ?>" href="settings.php">
-                <i class="bi bi-gear"></i>
-                <span>Settings</span>
-            </a>
+            <div class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle<?php if($active==='reports') echo ' active'; ?>" href="#" id="reportsDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                    <i class="bi bi-graph-up"></i>
+                    <span>Reports</span>
+                </a>
+                <ul class="dropdown-menu" aria-labelledby="reportsDropdown">
+                    <li><a class="dropdown-item" href="schedule-reports.php">Posting Report</a></li>
+                </ul>
+            </div>
         </div>
 
         <!-- Admin User Section -->
@@ -129,9 +134,14 @@ $version = trim(file_get_contents(__DIR__.'/../VERSION'));
                 </div>
             </div>
 
+            <!-- Settings -->
+            <a href="settings.php" class="settings-btn" title="Settings">
+                <i class="bi bi-gear"></i>
+            </a>
+
             <!-- Logout -->
             <a href="logout.php" class="logout-btn" title="Logout" onclick="return confirmLogout()">
-                <i class="bi bi-box-arrow-right"></i>
+                <i class="bi bi-power"></i>
             </a>
         </div>
 
@@ -169,6 +179,15 @@ $version = trim(file_get_contents(__DIR__.'/../VERSION'));
                 <i class="bi bi-people"></i>
                 <span>Users</span>
             </a>
+            <div class="dropdown">
+                <a class="nav-link dropdown-toggle<?php if($active==='reports') echo ' active'; ?>" href="#" id="reportsDropdownMobile" data-bs-toggle="dropdown" aria-expanded="false">
+                    <i class="bi bi-graph-up"></i>
+                    <span>Reports</span>
+                </a>
+                <ul class="dropdown-menu" aria-labelledby="reportsDropdownMobile">
+                    <li><a class="dropdown-item" href="schedule-reports.php">Posting Report</a></li>
+                </ul>
+            </div>
         </div>
     </div>
 </nav>

--- a/admin/inc/css/style.css
+++ b/admin/inc/css/style.css
@@ -3003,6 +3003,32 @@ table th, table td {
             box-shadow: 0 8px 25px rgba(245, 87, 108, 0.3);
         }
 
+        /* Settings Button */
+        .settings-btn {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 45px;
+            height: 45px;
+            border-radius: 12px;
+            background: rgba(255, 255, 255, 0.1);
+            color: rgba(255, 255, 255, 0.8);
+            text-decoration: none;
+            transition: var(--transition);
+            border: 2px solid transparent;
+        }
+
+        .settings-btn:hover {
+            background: var(--primary-gradient);
+            color: white;
+            transform: translateY(-2px);
+            box-shadow: 0 8px 25px rgba(102, 126, 234, 0.3);
+        }
+
+        .settings-btn i {
+            font-size: 1.25rem;
+        }
+
         .logout-btn i {
             font-size: 1.25rem;
         }

--- a/admin/schedule-reports.php
+++ b/admin/schedule-reports.php
@@ -5,7 +5,7 @@ require_once __DIR__.'/../lib/auth.php';
 require_once __DIR__.'/../lib/helpers.php';
 require_login();
 
-$active = 'calendars'; // keeps Calendars highlighted in nav
+$active = 'reports';
 $pdo = get_pdo();
 
 // --------------------


### PR DESCRIPTION
## Summary
- Move Settings into an icon beside the logout control and switch logout icon
- Introduce Reports dropdown with Posting Report link
- Remove Calendar page link to Social Health Report and highlight Reports for the report page

## Testing
- `php -l admin/header.php`
- `php -l admin/calendars.php`
- `php -l admin/schedule-reports.php`
- `php tests/dbtest.php`

------
https://chatgpt.com/codex/tasks/task_e_6896b8a821a883269e0cd881846df2ea