### PR TITLE
Reorder admin header icons and match settings style to logout

### DIFF
--- a/admin/header.php
+++ b/admin/header.php
@@ -106,14 +106,6 @@ $version = trim(file_get_contents(__DIR__.'/../VERSION'));
 
         <!-- Admin User Section -->
         <div class="admin-user-section">
-            <!-- Notifications -->
-            <div class="notification-container">
-                <div class="notification-bell" id="notifyWrap" title="Notifications">
-                    <i class="bi bi-bell notification-icon" id="notifyBell"></i>
-                    <span class="notification-badge" id="notifyCount">0</span>
-                </div>
-            </div>
-
             <!-- User Info -->
             <div class="admin-user-info">
                 <div class="admin-avatar">
@@ -123,19 +115,18 @@ $version = trim(file_get_contents(__DIR__.'/../VERSION'));
                     echo strtoupper(substr($firstName, 0, 1) . substr($lastName, 0, 1));
                     ?>
                 </div>
-                <div class="admin-details">
-                    <div class="admin-name">
-                        <?php
-                        $fullName = trim(($_SESSION['first_name'] ?? '') . ' ' . ($_SESSION['last_name'] ?? ''));
-                        echo htmlspecialchars($fullName ?: $_SESSION['username'] ?? 'Admin');
-                        ?>
-                    </div>
-                    <div class="admin-role">Administrator</div>
+            </div>
+
+            <!-- Notifications -->
+            <div class="notification-container">
+                <div class="notification-bell" id="notifyWrap" title="Notifications">
+                    <i class="bi bi-bell notification-icon" id="notifyBell"></i>
+                    <span class="notification-badge" id="notifyCount">0</span>
                 </div>
             </div>
 
             <!-- Settings -->
-            <a href="settings.php" class="settings-btn" title="Settings">
+            <a href="settings.php" class="logout-btn settings-btn" title="Settings">
                 <i class="bi bi-gear"></i>
             </a>
 

--- a/admin/inc/css/style.css
+++ b/admin/inc/css/style.css
@@ -2897,23 +2897,6 @@ table th, table td {
             box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
         }
 
-        .admin-details {
-            display: flex;
-            flex-direction: column;
-            line-height: 1.2;
-        }
-
-        .admin-name {
-            font-size: 0.875rem;
-            font-weight: 600;
-            color: white;
-        }
-
-        .admin-role {
-            font-size: 0.75rem;
-            color: rgba(255, 255, 255, 0.9);
-            font-weight: 500;
-        }
 
         /* Notification Bell */
         .notification-container {
@@ -2981,29 +2964,8 @@ table th, table td {
             100% { transform: scale(1); }
         }
 
-        /* Logout Button */
-        .logout-btn {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            width: 45px;
-            height: 45px;
-            border-radius: 12px;
-            background: rgba(255, 255, 255, 0.1);
-            color: rgba(255, 255, 255, 0.8);
-            text-decoration: none;
-            transition: var(--transition);
-            border: 2px solid transparent;
-        }
-
-        .logout-btn:hover {
-            background: var(--danger-gradient);
-            color: white;
-            transform: translateY(-2px);
-            box-shadow: 0 8px 25px rgba(245, 87, 108, 0.3);
-        }
-
-        /* Settings Button */
+        /* Header Icon Buttons */
+        .logout-btn,
         .settings-btn {
             display: flex;
             align-items: center;
@@ -3018,18 +2980,16 @@ table th, table td {
             border: 2px solid transparent;
         }
 
+        .logout-btn:hover,
         .settings-btn:hover {
-            background: var(--primary-gradient);
+            background: var(--danger-gradient);
             color: white;
             transform: translateY(-2px);
-            box-shadow: 0 8px 25px rgba(102, 126, 234, 0.3);
+            box-shadow: 0 8px 25px rgba(245, 87, 108, 0.3);
         }
 
+        .logout-btn i,
         .settings-btn i {
-            font-size: 1.25rem;
-        }
-
-        .logout-btn i {
             font-size: 1.25rem;
         }
 


### PR DESCRIPTION
## Summary
- Remove admin name/role from header and reorder icons: user initials, notifications, settings, logout
- Make settings button share logout styling for consistent look
- Clean up unused admin detail styles

## Testing
- `php -l admin/header.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6896bb8aaefc8326b798dce5f20da89d