### PR TITLE
style: unify login pages styling

### DIFF
--- a/admin/login.php
+++ b/admin/login.php
@@ -35,7 +35,7 @@ include __DIR__.'/login_header.php';
 ?>
 <div class="row justify-content-center">
     <div class="col-md-6 col-lg-4">
-        <div class="text-center">
+        <div class="text-center mb-4">
             <img src="/assets/images/mediahub-admin-logo.png" alt="MediaHub Admin" class="login-logo">
         </div>
         <div class="card shadow">

--- a/admin/login_header.php
+++ b/admin/login_header.php
@@ -11,6 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/assets/css/common.css">
     <link rel="stylesheet" href="inc/css/style.css">
 </head>
 <body class="login-page">

--- a/public/index.php
+++ b/public/index.php
@@ -68,13 +68,14 @@ if (!$isLoggedIn) {
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link href="https://fonts.googleapis.com/css2?family=Montserrat&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="/assets/css/common.css">
         <link rel="stylesheet" href="inc/css/style.css">
     </head>
     <body class="login-page">
     <div class="container">
         <div class="row justify-content-center">
             <div class="col-md-6 col-lg-4">
-                <div class="text-center">
+                <div class="text-center mb-4">
                     <img src="/assets/images/mediahub-logo.png" alt="MediaHub" class="login-logo">
                 </div>
                 <div class="card shadow">


### PR DESCRIPTION
## Summary
- use shared theme styles on store and admin login screens
- adjust logo spacing above login cards

## Testing
- `php -l public/index.php`
- `php -l admin/login.php`
- `php -l admin/login_header.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689752440edc8326a0a18574dd6a1db3