### PR TITLE
feat: add remember me and mobile login adjustments

### DIFF
--- a/admin/login.php
+++ b/admin/login.php
@@ -19,6 +19,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         } else {
             header('Location: index.php');
         }
+        if (!empty($_POST['remember'])) {
+            $rememberLifetime = 60 * 60 * 24 * 30;
+            setcookie('cm_admin_remember', '1', time() + $rememberLifetime, '/', '', isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on', true);
+            setcookie(session_name(), session_id(), time() + $rememberLifetime, '/', '', isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on', true);
+        }
         exit;
     } else {
         $errors[] = 'Login failed - Invalid username or password';
@@ -50,6 +55,10 @@ include __DIR__.'/login_header.php';
                     <div class="mb-3">
                         <label for="password" class="form-label">Password</label>
                         <input type="password" name="password" id="password" class="form-control form-control-lg" required>
+                    </div>
+                    <div class="form-check mb-3">
+                        <input class="form-check-input" type="checkbox" value="1" id="remember" name="remember">
+                        <label class="form-check-label" for="remember">Remember me</label>
                     </div>
                     <button class="btn btn-login btn-lg w-100" type="submit">Login</button>
                 </form>

--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -143,10 +143,17 @@ body {
 }
 
 .login-page {
-    background: linear-gradient(135deg, rgba(102,126,234,0.8) 0%, rgba(118,75,162,0.8) 100%);
+    background: linear-gradient(180deg, #4c5bd4 0%, #667eea 50%, #764ba2 100%);
     display: flex;
     align-items: center;
     min-height: 100vh;
+}
+
+@media (max-width: 576px) {
+    .login-page {
+        align-items: flex-start;
+        padding-top: 40px;
+    }
 }
 
 .login-page .login-logo {

--- a/public/index.php
+++ b/public/index.php
@@ -43,6 +43,13 @@ if (!$isLoggedIn) {
                 $_SESSION['store_user_id'] = $store['uid'] ?? null;
                 $_SESSION['store_first_name'] = $store['ufname'] ?? '';
                 $_SESSION['store_last_name'] = $store['ulname'] ?? '';
+
+                if (!empty($_POST['remember'])) {
+                    $rememberLifetime = 60 * 60 * 24 * 30;
+                    setcookie('cm_public_remember', '1', time() + $rememberLifetime, '/', '', isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on', true);
+                    setcookie(session_name(), session_id(), time() + $rememberLifetime, '/', '', isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on', true);
+                }
+
                 header('Location: index.php');
                 exit;
             } else {
@@ -92,6 +99,10 @@ if (!$isLoggedIn) {
                             <div class="mb-3">
                                 <label for="pin" class="form-label">Store PIN</label>
                                 <input type="text" name="pin" id="pin" class="form-control form-control-lg" required>
+                            </div>
+                            <div class="form-check mb-3">
+                                <input class="form-check-input" type="checkbox" value="1" id="remember" name="remember">
+                                <label class="form-check-label" for="remember">Remember me</label>
                             </div>
                             <button class="btn btn-login btn-lg w-100" type="submit">Login</button>
                         </form>


### PR DESCRIPTION
## Summary
- add persistent sessions for public and admin logins via "Remember me" checkbox
- shift login forms higher on small screens and update background gradient

## Testing
- `php -l lib/auth.php`
- `php -l public/index.php`
- `php -l admin/login.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6899649b603c8326bc44144228f24484