### PR TITLE
Improve login page layout

### DIFF
--- a/admin/login.php
+++ b/admin/login.php
@@ -62,6 +62,9 @@ include __DIR__.'/login_header.php';
                     </div>
                     <button class="btn btn-login btn-lg w-100" type="submit">Login</button>
                 </form>
+                <div class="text-center admin-link">
+                    <a href="/" class="text-muted text-decoration-none">Back to public</a>
+                </div>
             </div>
         </div>
     </div>

--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -143,7 +143,7 @@ body {
 }
 
 .login-page {
-    background: linear-gradient(180deg, #4c5bd4 0%, #667eea 50%, #764ba2 100%);
+    background: linear-gradient(180deg, #404db4 0%, #566bc7 50%, #644089 100%);
     display: flex;
     align-items: center;
     min-height: 100vh;
@@ -152,13 +152,23 @@ body {
 @media (max-width: 576px) {
     .login-page {
         align-items: flex-start;
-        padding-top: 40px;
+        padding-top: 20px;
     }
 }
 
 .login-page .login-logo {
-    max-width: 200px;
+    max-width: 230px;
     margin-bottom: 30px;
+}
+
+.login-page .form-check-input {
+    width: 1.5em;
+    height: 1.5em;
+}
+
+.login-page .admin-link {
+    margin-top: 20px;
+    font-size: 0.875rem;
 }
 
 .login-page .btn-login {


### PR DESCRIPTION
## Summary
- Darken login gradient, enlarge logo and remember-me checkbox, and reduce mobile top padding
- Add "Back to public" link to admin login and unify login link styling

## Testing
- `php -l admin/login.php`
- `php -l public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68996651b2288326b95450608a6d447c