### PR TITLE
Fix mobile calendar modal offset

### DIFF
--- a/public/inc/css/style.css
+++ b/public/inc/css/style.css
@@ -2808,6 +2808,14 @@ body {
     z-index: 9998 !important;
 }
 
+/* Offset modals for fixed header on small screens */
+@media (max-width: 768px) {
+    .modal {
+        /* Use header height to keep modals fully visible */
+        --bs-modal-margin: calc(var(--header-height) + 0.5rem);
+    }
+}
+
 .modal.show ~ .modal.show {
     z-index: 10000 !important;
 }


### PR DESCRIPTION
## Summary
- Ensure calendar modals remain visible on mobile by offsetting them from the fixed header

## Testing
- `php -l public/calendar.php`

------
https://chatgpt.com/codex/tasks/task_e_68a53b9d2660832698dea8fbfbf30b91