### PR TITLE
Fix mobile modals on calendar view

### DIFF
--- a/assets/css/calendar-mobile.css
+++ b/assets/css/calendar-mobile.css
@@ -5,8 +5,6 @@
 @media (max-width: 768px) {
     /* Prevent page from scrolling when modal is open */
     body.modal-open {
-        position: fixed !important;
-        width: 100% !important;
         overflow: hidden !important;
     }
 

--- a/public/calendar.php
+++ b/public/calendar.php
@@ -233,21 +233,6 @@ $extra_head = <<<HTML
 @media (max-width: 768px) {
     /* Fix for body scroll lock when modal is open */
     body.modal-open {
-        position: fixed !important;
-        width: 100% !important;
-        overflow: hidden !important;
-        top: 0 !important;
-        left: 0 !important;
-        right: 0 !important;
-    }
-    
-    /* Create a wrapper for proper scrolling context */
-    .modal-open .calendar-container {
-        position: fixed !important;
-        top: 0 !important;
-        left: 0 !important;
-        right: 0 !important;
-        bottom: 0 !important;
         overflow: hidden !important;
     }
     


### PR DESCRIPTION
## Summary
- prevent body from being fixed when calendar modals open so they stay in view on mobile
- drop extra calendar container scroll lock that pushed modals off-screen

## Testing
- `php -l public/calendar.php`


------
https://chatgpt.com/codex/tasks/task_e_68a601c2086c83268b1a3eb13a4f752a