### PR TITLE
fix: keep mobile modals visible

### DIFF
--- a/public/header.php
+++ b/public/header.php
@@ -231,6 +231,24 @@ $version = trim(file_get_contents(__DIR__.'/../VERSION'));
 </nav>
 
 <script>
+    // Set header height CSS variable for responsive spacing
+    document.addEventListener('DOMContentLoaded', function() {
+        const navbar = document.getElementById('modernNavbar');
+        if (navbar) {
+            document.documentElement.style.setProperty('--header-height', navbar.offsetHeight + 'px');
+        }
+
+        // Simplified mobile modal scroll lock
+        document.querySelectorAll('.modal').forEach(function(modal) {
+            modal.addEventListener('show.bs.modal', function() {
+                document.body.style.overflow = 'hidden';
+            });
+            modal.addEventListener('hidden.bs.modal', function() {
+                document.body.style.overflow = '';
+            });
+        });
+    });
+
     // Header scroll effect
     window.addEventListener('scroll', function() {
         const navbar = document.getElementById('modernNavbar');

--- a/public/inc/css/style.css
+++ b/public/inc/css/style.css
@@ -1,6 +1,6 @@
 /* Base Styles */
 body {
-    padding-top: 70px; /* Account for fixed header */
+    padding-top: var(--header-height, 70px); /* Account for fixed header */
 }
 
 .card {


### PR DESCRIPTION
## Summary
- make header height responsive so modal offset matches actual navbar size
- lock background scroll using overflow when showing modals on mobile

## Testing
- `php -l public/header.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a6047b95888326a13f42face9f8cc1