### PR TITLE
Disable blocking Bootstrap modal backdrop

### DIFF
--- a/public/inc/css/style.css
+++ b/public/inc/css/style.css
@@ -615,6 +615,7 @@ body {
 
 .modal-backdrop {
     z-index: 9990 !important;
+    display: none !important;
 }
 
 #eventModalCalendar {
@@ -2798,6 +2799,7 @@ body {
 
 .modal-backdrop {
     z-index: 9997 !important;
+    display: none !important;
 }
 
 .modal-backdrop.show ~ .modal-backdrop.show {


### PR DESCRIPTION
## Summary
- hide Bootstrap modal backdrop so it no longer obstructs modal interactions

## Testing
- ❌ `php tests/dbtest.php` (failed: SQLSTATE[HY000] [2002] No such file or directory)

------
https://chatgpt.com/codex/tasks/task_e_68a6095470b08326b286cdc9be64bb8d