### PR TITLE
Limit automatic Groundhogg sync to initial contact creation

### DIFF
--- a/admin/stores.php
+++ b/admin/stores.php
@@ -74,6 +74,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
                 [$ghSuccess, $ghMessage] = groundhogg_send_contact($contact);
                 if ($ghSuccess) {
+                    $updateSync = $pdo->prepare('UPDATE stores SET groundhogg_synced = 1 WHERE id = ?');
+                    $updateSync->execute([$storeId]);
                     $success[] = $ghMessage;
                 } else {
                     $errors[] = 'Store created but Groundhogg sync failed: ' . $ghMessage;

--- a/lib/groundhogg.php
+++ b/lib/groundhogg.php
@@ -504,6 +504,10 @@ function groundhogg_sync_store_contacts(int $store_id): array {
         ];
 
         [$success, $message] = groundhogg_send_contact($contact);
+        if ($success) {
+            $update = $pdo->prepare('UPDATE stores SET groundhogg_synced = 1 WHERE id = ?');
+            $update->execute([$store_id]);
+        }
         $results[] = [
             'email' => $store['admin_email'],
             'success' => $success,
@@ -536,6 +540,10 @@ function groundhogg_sync_store_contacts(int $store_id): array {
         ];
 
         [$success, $message] = groundhogg_send_contact($contact);
+        if ($success) {
+            $update = $pdo->prepare('UPDATE store_users SET groundhogg_synced = 1 WHERE id = ?');
+            $update->execute([$user['id']]);
+        }
         $results[] = [
             'email' => $user['email'],
             'success' => $success,

--- a/setup.php
+++ b/setup.php
@@ -27,6 +27,7 @@ $queries = [
         last_name VARCHAR(100),
         phone VARCHAR(50),
         address VARCHAR(255),
+        groundhogg_synced TINYINT(1) NOT NULL DEFAULT 0,
         marketing_report_url VARCHAR(255),
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
@@ -49,6 +50,7 @@ $queries = [
         email VARCHAR(255) NOT NULL,
         first_name VARCHAR(100),
         last_name VARCHAR(100),
+        groundhogg_synced TINYINT(1) NOT NULL DEFAULT 0,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         UNIQUE KEY store_email_unique (store_id, email),
         FOREIGN KEY (store_id) REFERENCES stores(id) ON DELETE CASCADE
@@ -305,6 +307,13 @@ try {
 }
 
 try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN groundhogg_synced TINYINT(1) DEFAULT 0 AFTER address");
+    echo "✓ Added groundhogg_synced column to stores table\n";
+} catch (PDOException $e) {
+    // Column might already exist
+}
+
+try {
     $pdo->exec("ALTER TABLE stores ADD COLUMN marketing_report_url VARCHAR(255) AFTER address");
     echo "✓ Added marketing_report_url column to stores table\n";
 } catch (PDOException $e) {
@@ -322,6 +331,13 @@ try {
 try {
     $pdo->exec("ALTER TABLE store_users ADD COLUMN last_name VARCHAR(100) AFTER first_name");
     echo "✓ Added last_name column to store_users table\n";
+} catch (PDOException $e) {
+    // Column might already exist
+}
+
+try {
+    $pdo->exec("ALTER TABLE store_users ADD COLUMN groundhogg_synced TINYINT(1) DEFAULT 0 AFTER last_name");
+    echo "✓ Added groundhogg_synced column to store_users table\n";
 } catch (PDOException $e) {
     // Column might already exist
 }


### PR DESCRIPTION
## Summary
- add groundhogg_synced tracking columns to stores and store_users tables
- skip automatic Groundhogg sync when editing stores once the contact has already been synchronized
- flag contacts as synced after successful API calls for store creation, user creation, and manual sync routines

## Testing
- php -l admin/stores.php
- php -l admin/edit_store.php
- php -l lib/groundhogg.php
- php -l setup.php

------
https://chatgpt.com/codex/tasks/task_e_68d482f4f1a08326b4e77e6ef403ae46