### PR TITLE
Add Groundhogg sync columns to stores and store_users

### DIFF
--- a/cmuploader.sql
+++ b/cmuploader.sql
@@ -600,6 +600,7 @@ CREATE TABLE `stores` (
   `last_name` varchar(100) DEFAULT NULL,
   `phone` varchar(50) DEFAULT NULL,
   `address` varchar(255) DEFAULT NULL,
+  `groundhogg_synced` tinyint(1) NOT NULL DEFAULT 0,
   `city` varchar(100) DEFAULT NULL,
   `state` varchar(100) DEFAULT NULL,
   `zip_code` varchar(20) DEFAULT NULL,
@@ -771,6 +772,7 @@ CREATE TABLE `store_users` (
   `email` varchar(255) NOT NULL,
   `first_name` varchar(100) DEFAULT NULL,
   `last_name` varchar(100) DEFAULT NULL,
+  `groundhogg_synced` tinyint(1) NOT NULL DEFAULT 0,
   `mobile_phone` varchar(50) DEFAULT NULL,
   `opt_in_status` enum('unconfirmed','confirmed','unsubscribed','subscribed_weekly','subscribed_monthly','bounced','spam','complained','blocked') DEFAULT 'confirmed',
   `created_at` timestamp NULL DEFAULT current_timestamp()

--- a/update_database.php
+++ b/update_database.php
@@ -189,7 +189,14 @@ try {
 }
 
 try {
-    $pdo->exec("ALTER TABLE store_users ADD COLUMN mobile_phone VARCHAR(50) AFTER last_name");
+    $pdo->exec("ALTER TABLE store_users ADD COLUMN groundhogg_synced TINYINT(1) DEFAULT 0 AFTER last_name");
+    echo "✓ Added groundhogg_synced column to store_users table\n";
+} catch (PDOException $e) {
+    echo "• groundhogg_synced column might already exist\n";
+}
+
+try {
+    $pdo->exec("ALTER TABLE store_users ADD COLUMN mobile_phone VARCHAR(50) AFTER groundhogg_synced");
     echo "✓ Added mobile_phone column to store_users table\n";
 } catch (PDOException $e) {
     echo "• mobile_phone column might already exist\n";
@@ -357,6 +364,13 @@ try {
     echo "✓ Added address column to stores table\n";
 } catch (PDOException $e) {
     echo "• address column might already exist\n";
+}
+
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN groundhogg_synced TINYINT(1) DEFAULT 0 AFTER address");
+    echo "✓ Added groundhogg_synced column to stores table\n";
+} catch (PDOException $e) {
+    echo "• groundhogg_synced column might already exist\n";
 }
 
 try {


### PR DESCRIPTION
## Summary
- add the `groundhogg_synced` column to the stores and store_users schema so new installations include it by default
- extend the database update script to backfill the new columns on existing databases

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4855ff2008326a3e0a7a9bc8f1da4