### PR TITLE
Improve admin user action styling

### DIFF
--- a/admin/inc/css/style.css
+++ b/admin/inc/css/style.css
@@ -2569,6 +2569,25 @@ body {
     margin-bottom: 2rem;
 }
 
+.users-card .actions-cell form {
+    margin: 0;
+}
+
+.users-card .actions-cell .btn-action {
+    box-shadow: var(--card-shadow);
+    transition: var(--transition);
+}
+
+.users-card .actions-cell .btn-action-primary {
+    background: var(--primary-gradient);
+    color: white;
+}
+
+.users-card .actions-cell .btn-action-primary:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--hover-shadow);
+}
+
 .user-avatar {
     width: 40px;
     height: 40px;
@@ -2609,6 +2628,15 @@ body {
     border-radius: 20px;
     box-shadow: var(--card-shadow);
     overflow: hidden;
+    margin-bottom: 2rem;
+}
+
+.add-user-card .card-body-modern {
+    padding: 1.75rem;
+}
+
+.add-user-form {
+    margin: 0;
 }
 
 .ts-dropdown .option {

--- a/admin/users.php
+++ b/admin/users.php
@@ -199,11 +199,11 @@ include __DIR__.'/header.php';
                                         <div><?php echo date('M j, Y', strtotime($u['created_at'])); ?></div>
                                         <small class="text-muted"><?php echo date('g:i A', strtotime($u['created_at'])); ?></small>
                                     </td>
-                                    <td>
+                                    <td class="actions-cell">
                                         <a href="edit_user.php?id=<?php echo $u['id']; ?>" class="btn btn-action btn-action-primary" title="Edit User">
                                             <i class="bi bi-pencil-square"></i> Edit
                                         </a>
-                                        <form method="post" class="d-inline" onsubmit="return confirm('Delete this user? This cannot be undone.');">
+                                        <form method="post" class="delete-user-form" onsubmit="return confirm('Delete this user? This cannot be undone.');">
                                             <input type="hidden" name="id" value="<?php echo $u['id']; ?>">
                                             <button class="btn btn-action btn-action-danger" name="delete" title="Delete User">
                                                 <i class="bi bi-trash"></i> Delete
@@ -227,7 +227,7 @@ include __DIR__.'/header.php';
                     Add New Admin User
                 </h5>
             </div>
-            <form method="post">
+            <form method="post" class="card-body-modern add-user-form">
                 <div class="form-section">
                     <h6 class="section-title">Account Information</h6>
                     <div class="row g-3">


### PR DESCRIPTION
## Summary
- align the admin user action buttons with the themed action-cell layout and hover styling
- add consistent card padding and spacing to the "Add New Admin User" form section

## Testing
- php -l admin/users.php

------
https://chatgpt.com/codex/tasks/task_e_68d4cd01a08483268464966763a2ef77