### PR TITLE
Remove text labels from admin user actions

### DIFF
--- a/admin/users.php
+++ b/admin/users.php
@@ -201,12 +201,12 @@ include __DIR__.'/header.php';
                                     </td>
                                     <td class="actions-cell">
                                         <a href="edit_user.php?id=<?php echo $u['id']; ?>" class="btn btn-action btn-action-primary" title="Edit User">
-                                            <i class="bi bi-pencil-square"></i> Edit
+                                            <i class="bi bi-pencil-square"></i>
                                         </a>
                                         <form method="post" class="delete-user-form" onsubmit="return confirm('Delete this user? This cannot be undone.');">
                                             <input type="hidden" name="id" value="<?php echo $u['id']; ?>">
                                             <button class="btn btn-action btn-action-danger" name="delete" title="Delete User">
-                                                <i class="bi bi-trash"></i> Delete
+                                                <i class="bi bi-trash"></i>
                                             </button>
                                         </form>
                                     </td>


### PR DESCRIPTION
## Summary
- remove the "Edit" and "Delete" text labels from the admin user table buttons so only the icons remain

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4cea685308326a9d2f77178c5dacd