### PR TITLE
Adjust admin dashboard stat card layout

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -188,53 +188,63 @@ include __DIR__.'/header.php';
 
         <!-- Statistics Grid -->
         <div class="stats-grid">
-            <a href="stores.php" class="stat-card stores animate__animated animate__fadeInUp">
+            <a href="stores.php" class="stat-card stat-card-horizontal stores animate__animated animate__fadeInUp">
                 <div class="stat-icon">
                     <i class="bi bi-shop"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['total_stores']; ?>">0</div>
-                <div class="stat-label">Total Stores</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['total_stores']; ?>">0</div>
+                    <div class="stat-label">Total Stores</div>
+                </div>
                 <div class="stat-bg"></div>
             </a>
 
-            <a href="uploads.php" class="stat-card uploads animate__animated animate__fadeInUp delay-10">
+            <a href="uploads.php" class="stat-card stat-card-horizontal uploads animate__animated animate__fadeInUp delay-10">
                 <div class="stat-icon">
                     <i class="bi bi-cloud-upload"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['total_uploads']; ?>">0</div>
-                <div class="stat-label">Total Uploads</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['total_uploads']; ?>">0</div>
+                    <div class="stat-label">Total Uploads</div>
+                </div>
                 <div class="stat-bg"></div>
             </a>
 
-            <a href="articles.php" class="stat-card articles animate__animated animate__fadeInUp delay-20">
+            <a href="articles.php" class="stat-card stat-card-horizontal articles animate__animated animate__fadeInUp delay-20">
                 <div class="stat-icon">
                     <i class="bi bi-file-text"></i>
                 </div>
-                <div>
-                    <span class="stat-number" data-count="<?php echo $stats['total_articles']; ?>">0</span>
-                    <?php if ($stats['pending_articles'] > 0): ?>
-                        <span class="stat-extra">(<?php echo $stats['pending_articles']; ?> pending)</span>
-                    <?php endif; ?>
+                <div class="stat-content">
+                    <div class="stat-header">
+                        <div class="stat-number" data-count="<?php echo $stats['total_articles']; ?>">0</div>
+                        <?php if ($stats['pending_articles'] > 0): ?>
+                            <span class="stat-extra">(<?php echo $stats['pending_articles']; ?> pending)</span>
+                        <?php endif; ?>
+                    </div>
+                    <div class="stat-label">Articles</div>
                 </div>
-                <div class="stat-label">Articles</div>
                 <div class="stat-bg"></div>
             </a>
 
-            <a href="broadcasts.php" class="stat-card messages animate__animated animate__fadeInUp delay-30">
+            <a href="broadcasts.php" class="stat-card stat-card-horizontal messages animate__animated animate__fadeInUp delay-30">
                 <div class="stat-icon">
                     <i class="bi bi-chat-dots"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['active_messages']; ?>">0</div>
-                <div class="stat-label">Active Messages</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['active_messages']; ?>">0</div>
+                    <div class="stat-label">Active Messages</div>
+                </div>
                 <div class="stat-bg"></div>
             </a>
 
-            <a href="stores.php" class="stat-card users animate__animated animate__fadeInUp delay-40">
+            <a href="stores.php" class="stat-card stat-card-horizontal users animate__animated animate__fadeInUp delay-40">
                 <div class="stat-icon">
                     <i class="bi bi-people"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['store_users']; ?>">0</div>
-                <div class="stat-label">Store Users</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['store_users']; ?>">0</div>
+                    <div class="stat-label">Store Users</div>
+                </div>
                 <div class="stat-bg"></div>
             </a>
         </div>

--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -44,6 +44,7 @@ body {
     margin-bottom: 2rem;
 }
 
+
 .stat-card {
     background: white;
     border-radius: 20px;
@@ -53,11 +54,15 @@ body {
     box-shadow: var(--card-shadow);
     transition: var(--transition);
     cursor: pointer;
+    display: block;
+    color: inherit;
+    text-decoration: none;
 }
 
 .stat-card:hover {
     transform: translateY(-5px);
     box-shadow: var(--hover-shadow);
+    text-decoration: none;
 }
 
 .stat-card .stat-icon {
@@ -87,6 +92,35 @@ body {
     height: 100px;
     border-radius: 50%;
     opacity: 0.1;
+}
+
+.stat-card-horizontal {
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+}
+
+.stat-card-horizontal .stat-icon {
+    margin-bottom: 0;
+    flex: 0 0 auto;
+    font-size: 2.75rem;
+}
+
+.stat-card-horizontal .stat-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    flex: 1;
+}
+
+.stat-card-horizontal .stat-header {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+}
+
+.stat-card-horizontal .stat-label {
+    margin-top: 0;
 }
 
 .card-header-modern {


### PR DESCRIPTION
## Summary
- rework admin dashboard stat cards so icons appear on the left with details grouped on the right
- add a horizontal stat card layout helper that removes link underlines and aligns text content cleanly

## Testing
- php -l admin/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d4d635f9288326b24dc8efca4284a6