### PR TITLE
Align stat cards with horizontal layout

### DIFF
--- a/admin/broadcasts.php
+++ b/admin/broadcasts.php
@@ -171,8 +171,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-megaphone-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['total_broadcasts']; ?>">0</div>
-                <div class="stat-label">Total Broadcasts</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['total_broadcasts']; ?>">0</div>
+                    <div class="stat-label">Total Broadcasts</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -180,8 +182,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-globe"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['global_messages']; ?>">0</div>
-                <div class="stat-label">Global Messages</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['global_messages']; ?>">0</div>
+                    <div class="stat-label">Global Messages</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -189,8 +193,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-shop"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['store_messages']; ?>">0</div>
-                <div class="stat-label">Store Messages</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['store_messages']; ?>">0</div>
+                    <div class="stat-label">Store Messages</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -198,8 +204,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-calendar-week"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['this_week']; ?>">0</div>
-                <div class="stat-label">This Week</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['this_week']; ?>">0</div>
+                    <div class="stat-label">This Week</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -207,8 +215,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-calendar-month"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['this_month']; ?>">0</div>
-                <div class="stat-label">This Month</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['this_month']; ?>">0</div>
+                    <div class="stat-label">This Month</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -216,8 +226,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-activity"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['active_stores']; ?>">0</div>
-                <div class="stat-label">Active Stores</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['active_stores']; ?>">0</div>
+                    <div class="stat-label">Active Stores</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
         </div>

--- a/admin/chat.php
+++ b/admin/chat.php
@@ -212,8 +212,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-chat-dots-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['total_conversations']; ?>">0</div>
-                <div class="stat-label">Total Conversations</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['total_conversations']; ?>">0</div>
+                    <div class="stat-label">Total Conversations</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -221,8 +223,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-envelope-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['unread_messages']; ?>">0</div>
-                <div class="stat-label">Unread Messages</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['unread_messages']; ?>">0</div>
+                    <div class="stat-label">Unread Messages</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -230,8 +234,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-calendar-check-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['today_messages']; ?>">0</div>
-                <div class="stat-label">Today's Messages</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['today_messages']; ?>">0</div>
+                    <div class="stat-label">Today's Messages</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -239,8 +245,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-activity"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['active_chats']; ?>">0</div>
-                <div class="stat-label">Active Chats (24h)</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['active_chats']; ?>">0</div>
+                    <div class="stat-label">Active Chats (24h)</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
         </div>

--- a/admin/stores.php
+++ b/admin/stores.php
@@ -196,8 +196,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-shop"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $total_stores; ?>">0</div>
-                <div class="stat-label">Total Stores</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $total_stores; ?>">0</div>
+                    <div class="stat-label">Total Stores</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -205,8 +207,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-cloud-upload"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $total_uploads; ?>">0</div>
-                <div class="stat-label">Total Uploads</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $total_uploads; ?>">0</div>
+                    <div class="stat-label">Total Uploads</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -214,8 +218,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-chat-dots"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $total_chats; ?>">0</div>
-                <div class="stat-label">Total Chats</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $total_chats; ?>">0</div>
+                    <div class="stat-label">Total Chats</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -223,8 +229,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-activity"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stores_with_uploads; ?>">0</div>
-                <div class="stat-label">Active Stores</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stores_with_uploads; ?>">0</div>
+                    <div class="stat-label">Active Stores</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
         </div>

--- a/admin/uploads.php
+++ b/admin/uploads.php
@@ -251,8 +251,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-cloud-upload-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['total_uploads']; ?>">0</div>
-                <div class="stat-label">Total Uploads</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['total_uploads']; ?>">0</div>
+                    <div class="stat-label">Total Uploads</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -260,8 +262,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-calendar-week-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['week_uploads']; ?>">0</div>
-                <div class="stat-label">This Week</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['week_uploads']; ?>">0</div>
+                    <div class="stat-label">This Week</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -269,8 +273,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-calendar-check-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['today_uploads']; ?>">0</div>
-                <div class="stat-label">Today</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['today_uploads']; ?>">0</div>
+                    <div class="stat-label">Today</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -278,8 +284,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-image-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['total_images']; ?>">0</div>
-                <div class="stat-label">Images</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['total_images']; ?>">0</div>
+                    <div class="stat-label">Images</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -287,8 +295,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-camera-video-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['total_videos']; ?>">0</div>
-                <div class="stat-label">Videos</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['total_videos']; ?>">0</div>
+                    <div class="stat-label">Videos</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -296,8 +306,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-clock-history"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['pending_review']; ?>">0</div>
-                <div class="stat-label">Pending Review</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['pending_review']; ?>">0</div>
+                    <div class="stat-label">Pending Review</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
         </div>

--- a/admin/users.php
+++ b/admin/users.php
@@ -114,8 +114,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-people-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $total_users; ?>">0</div>
-                <div class="stat-label">Total Users</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $total_users; ?>">0</div>
+                    <div class="stat-label">Total Users</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -123,8 +125,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-person-plus-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $recent_users; ?>">0</div>
-                <div class="stat-label">Recent (30 days)</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $recent_users; ?>">0</div>
+                    <div class="stat-label">Recent (30 days)</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -132,8 +136,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-person-check-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $active_users; ?>">0</div>
-                <div class="stat-label">Active Users</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $active_users; ?>">0</div>
+                    <div class="stat-label">Active Users</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
         </div>

--- a/assets/css/calendar-mobile.css
+++ b/assets/css/calendar-mobile.css
@@ -321,7 +321,7 @@
 
     .stat-icon {
         font-size: 1.25rem;
-        margin-bottom: 0.25rem;
+        margin-bottom: 0;
     }
 
     .stat-number {

--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -54,7 +54,9 @@ body {
     box-shadow: var(--card-shadow);
     transition: var(--transition);
     cursor: pointer;
-    display: block;
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
     color: inherit;
     text-decoration: none;
 }
@@ -67,8 +69,18 @@ body {
 
 .stat-card .stat-icon {
     font-size: 2.5rem;
-    margin-bottom: 0.5rem;
     opacity: 0.9;
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.stat-card .stat-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    flex: 1;
 }
 
 .stat-number {

--- a/public/articles.php
+++ b/public/articles.php
@@ -382,8 +382,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-file-text-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['total_articles']; ?>">0</div>
-                <div class="stat-label">Total Articles</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['total_articles']; ?>">0</div>
+                    <div class="stat-label">Total Articles</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -391,8 +393,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-clock-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['pending_articles']; ?>">0</div>
-                <div class="stat-label">Pending Review</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['pending_articles']; ?>">0</div>
+                    <div class="stat-label">Pending Review</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -400,8 +404,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-check-circle-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['approved_articles']; ?>">0</div>
-                <div class="stat-label">Approved</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['approved_articles']; ?>">0</div>
+                    <div class="stat-label">Approved</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -409,8 +415,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-x-circle-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['rejected_articles']; ?>">0</div>
-                <div class="stat-label">Rejected</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['rejected_articles']; ?>">0</div>
+                    <div class="stat-label">Rejected</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -418,8 +426,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-file-earmark-text"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['draft_articles']; ?>">0</div>
-                <div class="stat-label">Drafts</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['draft_articles']; ?>">0</div>
+                    <div class="stat-label">Drafts</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -427,8 +437,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-graph-up-arrow"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $approval_rate; ?>">0</div>
-                <div class="stat-label">Approval Rate %</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $approval_rate; ?>">0</div>
+                    <div class="stat-label">Approval Rate %</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
         </div>

--- a/public/chat.php
+++ b/public/chat.php
@@ -83,8 +83,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-chat-dots-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['total_messages']; ?>" data-stat="total">0</div>
-                <div class="stat-label">Total Messages</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['total_messages']; ?>" data-stat="total">0</div>
+                    <div class="stat-label">Total Messages</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -92,8 +94,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-person-badge-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['admin_messages']; ?>" data-stat="admin">0</div>
-                <div class="stat-label">From Admin</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['admin_messages']; ?>" data-stat="admin">0</div>
+                    <div class="stat-label">From Admin</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -101,8 +105,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-person-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['your_messages']; ?>" data-stat="store">0</div>
-                <div class="stat-label">Your Messages</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['your_messages']; ?>" data-stat="store">0</div>
+                    <div class="stat-label">Your Messages</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -110,8 +116,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-hand-thumbs-up-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['liked_messages']; ?>" data-stat="liked">0</div>
-                <div class="stat-label">Liked</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['liked_messages']; ?>" data-stat="liked">0</div>
+                    <div class="stat-label">Liked</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -119,8 +127,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-heart-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['loved_messages']; ?>" data-stat="loved">0</div>
-                <div class="stat-label">Loved</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['loved_messages']; ?>" data-stat="loved">0</div>
+                    <div class="stat-label">Loved</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -128,8 +138,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-clock-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['recent_messages']; ?>" data-stat="recent">0</div>
-                <div class="stat-label">This Week</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['recent_messages']; ?>" data-stat="recent">0</div>
+                    <div class="stat-label">This Week</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
         </div>

--- a/public/history.php
+++ b/public/history.php
@@ -371,8 +371,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-folder-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['total_files']; ?>">0</div>
-                <div class="stat-label">Total Files</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['total_files']; ?>">0</div>
+                    <div class="stat-label">Total Files</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -380,8 +382,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-hdd-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo number_format($total_size_gb, 1); ?>">0</div>
-                <div class="stat-label">GB Storage</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo number_format($total_size_gb, 1); ?>">0</div>
+                    <div class="stat-label">GB Storage</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -389,8 +393,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-image-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['total_images']; ?>">0</div>
-                <div class="stat-label">Images</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['total_images']; ?>">0</div>
+                    <div class="stat-label">Images</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -398,8 +404,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-camera-video-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['total_videos']; ?>">0</div>
-                <div class="stat-label">Videos</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['total_videos']; ?>">0</div>
+                    <div class="stat-label">Videos</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -407,8 +415,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-clock-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['recent_uploads']; ?>">0</div>
-                <div class="stat-label">This Week</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['recent_uploads']; ?>">0</div>
+                    <div class="stat-label">This Week</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
         </div>

--- a/public/inc/css/articles.css
+++ b/public/inc/css/articles.css
@@ -44,10 +44,13 @@
     background: white;
     border-radius: 20px;
     padding: 1.5rem;
-    text-align: center;
     overflow: hidden;
     box-shadow: var(--card-shadow);
     transition: var(--transition);
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+    text-align: left;
 }
 
 .stat-card:hover {
@@ -75,9 +78,20 @@
 
 .stat-icon {
     font-size: 2rem;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0;
     position: relative;
     z-index: 1;
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.stat-card .stat-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    flex: 1;
 }
 
 .stat-number {

--- a/public/inc/css/style.css
+++ b/public/inc/css/style.css
@@ -109,14 +109,28 @@ body {
     background: white;
     border-radius: 20px;
     padding: 1.5rem;
-    text-align: center;
     overflow: hidden;
     box-shadow: var(--card-shadow);
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+    text-align: left;
 }
 
 .stat-icon {
     font-size: 2rem;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0;
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.stat-card .stat-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    flex: 1;
 }
 
 .stat-number {

--- a/public/index.php
+++ b/public/index.php
@@ -613,8 +613,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-cloud-upload-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $upload_stats['total_uploads']; ?>">0</div>
-                <div class="stat-label">Total Uploads</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $upload_stats['total_uploads']; ?>">0</div>
+                    <div class="stat-label">Total Uploads</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -622,13 +624,15 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-calendar-week-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $upload_stats['week_uploads']; ?>">0</div>
-                <div class="stat-label">This Week</div>
-                <?php if ($upload_stats['week_uploads'] > 0): ?>
-                    <div class="stat-change positive">
-                        <i class="bi bi-arrow-up"></i> Active
-                    </div>
-                <?php endif; ?>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $upload_stats['week_uploads']; ?>">0</div>
+                    <div class="stat-label">This Week</div>
+                    <?php if ($upload_stats['week_uploads'] > 0): ?>
+                        <div class="stat-change positive">
+                            <i class="bi bi-arrow-up"></i> Active
+                        </div>
+                    <?php endif; ?>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -636,8 +640,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-image-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $upload_stats['total_images']; ?>">0</div>
-                <div class="stat-label">Images</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $upload_stats['total_images']; ?>">0</div>
+                    <div class="stat-label">Images</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -645,8 +651,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-camera-video-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $upload_stats['total_videos']; ?>">0</div>
-                <div class="stat-label">Videos</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $upload_stats['total_videos']; ?>">0</div>
+                    <div class="stat-label">Videos</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -654,8 +662,10 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-calendar-event-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $upcoming_posts; ?>">0</div>
-                <div class="stat-label">Scheduled Posts</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $upcoming_posts; ?>">0</div>
+                    <div class="stat-label">Scheduled Posts</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
@@ -663,13 +673,15 @@ include __DIR__.'/header.php';
                 <div class="stat-icon">
                     <i class="bi bi-chat-dots-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $unread_count; ?>">0</div>
-                <div class="stat-label">Unread Messages</div>
-                <?php if ($unread_count > 0): ?>
-                    <div class="stat-change positive">
-                        <i class="bi bi-circle-fill"></i> New
-                    </div>
-                <?php endif; ?>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $unread_count; ?>">0</div>
+                    <div class="stat-label">Unread Messages</div>
+                    <?php if ($unread_count > 0): ?>
+                        <div class="stat-change positive">
+                            <i class="bi bi-circle-fill"></i> New
+                        </div>
+                    <?php endif; ?>
+                </div>
                 <div class="stat-bg"></div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- update shared stat card styles to lay out icons and content horizontally
- wrap stat metrics in a unified content container across admin and public dashboards
- tweak mobile calendar styles to keep icons aligned with the new presentation

## Testing
- php -l admin/stores.php admin/users.php admin/broadcasts.php admin/chat.php admin/uploads.php public/index.php public/articles.php public/chat.php public/history.php

------
https://chatgpt.com/codex/tasks/task_e_68d4d7810ea88326b2a5d915da01eff4