### PR TITLE
Restyle admin stats cards with horizontal layout

### DIFF
--- a/admin/broadcasts.php
+++ b/admin/broadcasts.php
@@ -167,57 +167,69 @@ include __DIR__.'/header.php';
 
         <!-- Statistics -->
         <div class="stats-grid">
-            <div class="stat-card primary animate__animated animate__fadeInUp">
+            <div class="stat-card stat-card-horizontal primary animate__animated animate__fadeInUp">
                 <div class="stat-icon">
                     <i class="bi bi-megaphone-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['total_broadcasts']; ?>">0</div>
-                <div class="stat-label">Total Broadcasts</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['total_broadcasts']; ?>">0</div>
+                    <div class="stat-label">Total Broadcasts</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card success animate__animated animate__fadeInUp delay-10">
+            <div class="stat-card stat-card-horizontal success animate__animated animate__fadeInUp delay-10">
                 <div class="stat-icon">
                     <i class="bi bi-globe"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['global_messages']; ?>">0</div>
-                <div class="stat-label">Global Messages</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['global_messages']; ?>">0</div>
+                    <div class="stat-label">Global Messages</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card warning animate__animated animate__fadeInUp delay-20">
+            <div class="stat-card stat-card-horizontal warning animate__animated animate__fadeInUp delay-20">
                 <div class="stat-icon">
                     <i class="bi bi-shop"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['store_messages']; ?>">0</div>
-                <div class="stat-label">Store Messages</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['store_messages']; ?>">0</div>
+                    <div class="stat-label">Store Messages</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card info animate__animated animate__fadeInUp delay-30">
+            <div class="stat-card stat-card-horizontal info animate__animated animate__fadeInUp delay-30">
                 <div class="stat-icon">
                     <i class="bi bi-calendar-week"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['this_week']; ?>">0</div>
-                <div class="stat-label">This Week</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['this_week']; ?>">0</div>
+                    <div class="stat-label">This Week</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card danger animate__animated animate__fadeInUp delay-40">
+            <div class="stat-card stat-card-horizontal danger animate__animated animate__fadeInUp delay-40">
                 <div class="stat-icon">
                     <i class="bi bi-calendar-month"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['this_month']; ?>">0</div>
-                <div class="stat-label">This Month</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['this_month']; ?>">0</div>
+                    <div class="stat-label">This Month</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card secondary animate__animated animate__fadeInUp delay-50">
+            <div class="stat-card stat-card-horizontal secondary animate__animated animate__fadeInUp delay-50">
                 <div class="stat-icon">
                     <i class="bi bi-activity"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['active_stores']; ?>">0</div>
-                <div class="stat-label">Active Stores</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['active_stores']; ?>">0</div>
+                    <div class="stat-label">Active Stores</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
         </div>

--- a/admin/chat.php
+++ b/admin/chat.php
@@ -208,39 +208,47 @@ include __DIR__.'/header.php';
 
         <!-- Statistics -->
         <div class="stats-grid">
-            <div class="stat-card primary animate__animated animate__fadeInUp">
+            <div class="stat-card stat-card-horizontal primary animate__animated animate__fadeInUp">
                 <div class="stat-icon">
                     <i class="bi bi-chat-dots-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['total_conversations']; ?>">0</div>
-                <div class="stat-label">Total Conversations</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['total_conversations']; ?>">0</div>
+                    <div class="stat-label">Total Conversations</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card warning animate__animated animate__fadeInUp delay-10">
+            <div class="stat-card stat-card-horizontal warning animate__animated animate__fadeInUp delay-10">
                 <div class="stat-icon">
                     <i class="bi bi-envelope-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['unread_messages']; ?>">0</div>
-                <div class="stat-label">Unread Messages</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['unread_messages']; ?>">0</div>
+                    <div class="stat-label">Unread Messages</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card success animate__animated animate__fadeInUp delay-20">
+            <div class="stat-card stat-card-horizontal success animate__animated animate__fadeInUp delay-20">
                 <div class="stat-icon">
                     <i class="bi bi-calendar-check-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['today_messages']; ?>">0</div>
-                <div class="stat-label">Today's Messages</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['today_messages']; ?>">0</div>
+                    <div class="stat-label">Today's Messages</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card info animate__animated animate__fadeInUp delay-30">
+            <div class="stat-card stat-card-horizontal info animate__animated animate__fadeInUp delay-30">
                 <div class="stat-icon">
                     <i class="bi bi-activity"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['active_chats']; ?>">0</div>
-                <div class="stat-label">Active Chats (24h)</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['active_chats']; ?>">0</div>
+                    <div class="stat-label">Active Chats (24h)</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
         </div>

--- a/admin/stores.php
+++ b/admin/stores.php
@@ -192,39 +192,47 @@ include __DIR__.'/header.php';
 
         <!-- Statistics -->
         <div class="stats-grid">
-            <div class="stat-card primary animate__animated animate__fadeInUp">
+            <div class="stat-card stat-card-horizontal primary animate__animated animate__fadeInUp">
                 <div class="stat-icon">
                     <i class="bi bi-shop"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $total_stores; ?>">0</div>
-                <div class="stat-label">Total Stores</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $total_stores; ?>">0</div>
+                    <div class="stat-label">Total Stores</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card success animate__animated animate__fadeInUp delay-10">
+            <div class="stat-card stat-card-horizontal success animate__animated animate__fadeInUp delay-10">
                 <div class="stat-icon">
                     <i class="bi bi-cloud-upload"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $total_uploads; ?>">0</div>
-                <div class="stat-label">Total Uploads</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $total_uploads; ?>">0</div>
+                    <div class="stat-label">Total Uploads</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card warning animate__animated animate__fadeInUp delay-20">
+            <div class="stat-card stat-card-horizontal warning animate__animated animate__fadeInUp delay-20">
                 <div class="stat-icon">
                     <i class="bi bi-chat-dots"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $total_chats; ?>">0</div>
-                <div class="stat-label">Total Chats</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $total_chats; ?>">0</div>
+                    <div class="stat-label">Total Chats</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card info animate__animated animate__fadeInUp delay-30">
+            <div class="stat-card stat-card-horizontal info animate__animated animate__fadeInUp delay-30">
                 <div class="stat-icon">
                     <i class="bi bi-activity"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stores_with_uploads; ?>">0</div>
-                <div class="stat-label">Active Stores</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stores_with_uploads; ?>">0</div>
+                    <div class="stat-label">Active Stores</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
         </div>

--- a/admin/uploads.php
+++ b/admin/uploads.php
@@ -247,57 +247,69 @@ include __DIR__.'/header.php';
 
         <!-- Statistics -->
         <div class="stats-grid">
-            <div class="stat-card primary animate__animated animate__fadeInUp active" data-filter="total">
+            <div class="stat-card stat-card-horizontal primary animate__animated animate__fadeInUp active" data-filter="total">
                 <div class="stat-icon">
                     <i class="bi bi-cloud-upload-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['total_uploads']; ?>">0</div>
-                <div class="stat-label">Total Uploads</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['total_uploads']; ?>">0</div>
+                    <div class="stat-label">Total Uploads</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card success animate__animated animate__fadeInUp delay-10" data-filter="week">
+            <div class="stat-card stat-card-horizontal success animate__animated animate__fadeInUp delay-10" data-filter="week">
                 <div class="stat-icon">
                     <i class="bi bi-calendar-week-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['week_uploads']; ?>">0</div>
-                <div class="stat-label">This Week</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['week_uploads']; ?>">0</div>
+                    <div class="stat-label">This Week</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card warning animate__animated animate__fadeInUp delay-20" data-filter="today">
+            <div class="stat-card stat-card-horizontal warning animate__animated animate__fadeInUp delay-20" data-filter="today">
                 <div class="stat-icon">
                     <i class="bi bi-calendar-check-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['today_uploads']; ?>">0</div>
-                <div class="stat-label">Today</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['today_uploads']; ?>">0</div>
+                    <div class="stat-label">Today</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card info animate__animated animate__fadeInUp delay-30" data-filter="images">
+            <div class="stat-card stat-card-horizontal info animate__animated animate__fadeInUp delay-30" data-filter="images">
                 <div class="stat-icon">
                     <i class="bi bi-image-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['total_images']; ?>">0</div>
-                <div class="stat-label">Images</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['total_images']; ?>">0</div>
+                    <div class="stat-label">Images</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card danger animate__animated animate__fadeInUp delay-40" data-filter="videos">
+            <div class="stat-card stat-card-horizontal danger animate__animated animate__fadeInUp delay-40" data-filter="videos">
                 <div class="stat-icon">
                     <i class="bi bi-camera-video-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['total_videos']; ?>">0</div>
-                <div class="stat-label">Videos</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['total_videos']; ?>">0</div>
+                    <div class="stat-label">Videos</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card secondary animate__animated animate__fadeInUp delay-50" data-filter="pending">
+            <div class="stat-card stat-card-horizontal secondary animate__animated animate__fadeInUp delay-50" data-filter="pending">
                 <div class="stat-icon">
                     <i class="bi bi-clock-history"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $stats['pending_review']; ?>">0</div>
-                <div class="stat-label">Pending Review</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $stats['pending_review']; ?>">0</div>
+                    <div class="stat-label">Pending Review</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
         </div>

--- a/admin/users.php
+++ b/admin/users.php
@@ -110,30 +110,36 @@ include __DIR__.'/header.php';
 
         <!-- Statistics -->
         <div class="stats-grid">
-            <div class="stat-card primary animate__animated animate__fadeInUp">
+            <div class="stat-card stat-card-horizontal primary animate__animated animate__fadeInUp">
                 <div class="stat-icon">
                     <i class="bi bi-people-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $total_users; ?>">0</div>
-                <div class="stat-label">Total Users</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $total_users; ?>">0</div>
+                    <div class="stat-label">Total Users</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card success animate__animated animate__fadeInUp delay-10">
+            <div class="stat-card stat-card-horizontal success animate__animated animate__fadeInUp delay-10">
                 <div class="stat-icon">
                     <i class="bi bi-person-plus-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $recent_users; ?>">0</div>
-                <div class="stat-label">Recent (30 days)</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $recent_users; ?>">0</div>
+                    <div class="stat-label">Recent (30 days)</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card warning animate__animated animate__fadeInUp delay-20">
+            <div class="stat-card stat-card-horizontal warning animate__animated animate__fadeInUp delay-20">
                 <div class="stat-icon">
                     <i class="bi bi-person-check-fill"></i>
                 </div>
-                <div class="stat-number" data-count="<?php echo $active_users; ?>">0</div>
-                <div class="stat-label">Active Users</div>
+                <div class="stat-content">
+                    <div class="stat-number" data-count="<?php echo $active_users; ?>">0</div>
+                    <div class="stat-label">Active Users</div>
+                </div>
                 <div class="stat-bg"></div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- restyle the statistic cards across admin pages to use the horizontal layout with the icon on the left and text on the right
- ensure uploads page filter cards follow the same layout for visual consistency

## Testing
- php -l admin/stores.php
- php -l admin/broadcasts.php
- php -l admin/chat.php
- php -l admin/users.php
- php -l admin/uploads.php

------
https://chatgpt.com/codex/tasks/task_e_68d4d9b0987483268ed5fb3ae895cf20